### PR TITLE
Fix references

### DIFF
--- a/Source/Infrastructure/Infrastructure.csproj
+++ b/Source/Infrastructure/Infrastructure.csproj
@@ -7,5 +7,6 @@
 		<PackageReference Include="pulumi.azuread" Version="5.26.1" />
 		<PackageReference Include="pulumi.azurenative" Version="1.67.0" />
 		<PackageReference Include="Pulumi.Mongodbatlas" Version="3.5.0" />
+        <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
 	</ItemGroup>
 </Project>

--- a/Source/Reactions/Reactions.csproj
+++ b/Source/Reactions/Reactions.csproj
@@ -8,7 +8,6 @@
 	<ItemGroup>
 		<PackageReference Include="handlebars.net" Version="2.1.2" />
 		<PackageReference Include="Azure.Storage.Files.Shares" Version="12.11.0" />
-        <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
         <PackageReference Include="semver" Version="2.2.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
### Fixed

- Bootstrapper should now be able to deploy the AppManager and then hand over the stack it created to the cloud counterpart engine.
