### PR TITLE
Getting existing resource group instead of trying to create it

### DIFF
--- a/Source/Reactions/Applications/Pulumi/ApplicationResourceGroupPulumiExtensions.cs
+++ b/Source/Reactions/Applications/Pulumi/ApplicationResourceGroupPulumiExtensions.cs
@@ -11,6 +11,22 @@ public static class ApplicationResourceGroupPulumiExtensions
 {
     public static ResourceGroup SetupResourceGroup(this Application application, CloudRuntimeEnvironment environment)
     {
+        var name = GetResourceGroupName(application, environment);
+        return new ResourceGroup(name, new()
+        {
+            Location = application.CloudLocation.Value,
+            ResourceGroupName = name,
+            Tags = application.GetTags(environment)
+        });
+    }
+
+    public static ResourceGroup GetResourceGroup(this Application application, CloudRuntimeEnvironment environment)
+    {
+        return ResourceGroup.Get(GetResourceGroupName(application, environment), application.Resources.AzureResourceGroupId.Value);
+    }
+
+    static string GetResourceGroupName(Application application, CloudRuntimeEnvironment environment)
+    {
         var locationString = () => application.CloudLocation.Value switch
         {
             CloudLocationKey.NorwayEast => "Norway",
@@ -19,13 +35,6 @@ public static class ApplicationResourceGroupPulumiExtensions
             _ => "NA"
         };
 
-        var name = $"{application.Name}-{environment.ToShortName()}-{locationString()}-RG";
-
-        return new ResourceGroup(name, new()
-        {
-            Location = application.CloudLocation.Value,
-            ResourceGroupName = name,
-            Tags = application.GetTags(environment)
-        });
+        return $"{application.Name}-{environment.ToShortName()}-{locationString()}-RG";
     }
 }

--- a/Source/Reactions/Applications/Pulumi/PulumiStackDefinitions.cs
+++ b/Source/Reactions/Applications/Pulumi/PulumiStackDefinitions.cs
@@ -107,7 +107,7 @@ public class PulumiStackDefinitions : IPulumiStackDefinitions
         IEnumerable<Deployable>? deployables = default)
     {
         var tags = application.GetTags(environment);
-        resourceGroup ??= application.SetupResourceGroup(environment);
+        resourceGroup ??= application.GetResourceGroup(environment);
         var storage = await microservice.GetStorage(application, resourceGroup, _fileStorageLogger);
         storage.CreateAndUploadAppSettings(_settings);
         storage.CreateAndUploadClusterClientConfig(storage.FileStorage.ConnectionString);
@@ -143,7 +143,7 @@ public class PulumiStackDefinitions : IPulumiStackDefinitions
         CloudRuntimeEnvironment environment)
     {
         var tags = application.GetTags(environment);
-        var resourceGroup = application.SetupResourceGroup(environment);
+        var resourceGroup = application.GetResourceGroup(environment);
         var storage = await microservice.GetStorage(application, resourceGroup, _fileStorageLogger);
 
         var managedEnvironment = await application.GetContainerAppManagedEnvironment(resourceGroup, environment);


### PR DESCRIPTION
### Fixed

- Getting existing resource group for application for microservice stacks, instead of creating new ones - which will conflict.
