### PR TITLE
Removing temporary endpoint

### DIFF
--- a/Source/Domain/Applications/Application.cs
+++ b/Source/Domain/Applications/Application.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Concepts.Applications;
-using Concepts.Applications.Environments;
 using Events.Applications;
-using Events.Applications.Environments;
 
 namespace Domain.Applications;
 

--- a/Source/Domain/Applications/Application.cs
+++ b/Source/Domain/Applications/Application.cs
@@ -31,8 +31,4 @@ public class Application : Controller
     [HttpPost("secrets")]
     public Task SetSecretForApplication([FromRoute] ApplicationId applicationId, [FromBody] Secret secret) =>
         _eventLog.Append(applicationId, new SecretSetForApplication(secret.Key, secret.Value));
-
-    [HttpPost("add-environment/{environmentId}")]
-    public Task AddEnvironmentToApplication([FromRoute] ApplicationId applicationId, [FromRoute] ApplicationEnvironmentId environmentId) =>
-        _eventLog.Append(applicationId, new ApplicationEnvironmentAddedToApplication(environmentId));
 }


### PR DESCRIPTION
### Fixed

- Removed temporary endpoint for associating application environment with application. This was a temporary need to get an event in.
