### PR TITLE
Upgrade Cratis

### DIFF
--- a/Source/Environment/docker-compose.yml
+++ b/Source/Environment/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   cratis-kernel:
-    image: aksioinsurtech/cratis:8.10.0-development
+    image: aksioinsurtech/cratis:8.11.1-development
 
     volumes:
       - ./cratis.json:/app/cratis.json:ro

--- a/Source/Web/package.json
+++ b/Source/Web/package.json
@@ -13,11 +13,11 @@
         "up": "ncu -u"
     },
     "dependencies": {
-        "@aksio/cratis-applications-frontend": "8.10.0",
-        "@aksio/cratis-fundamentals": "8.10.0",
-        "@aksio/cratis-mui": "8.10.0",
-        "@aksio/cratis-react": "8.10.0",
-        "@aksio/cratis-typescript": "8.10.0",
+        "@aksio/cratis-applications-frontend": "8.11.1",
+        "@aksio/cratis-fundamentals": "8.11.1",
+        "@aksio/cratis-mui": "8.11.1",
+        "@aksio/cratis-react": "8.11.1",
+        "@aksio/cratis-typescript": "8.11.1",
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@monaco-editor/react": "^4.4.6",
@@ -31,7 +31,7 @@
         "react-router-dom": "6.4.2"
     },
     "devDependencies": {
-        "@aksio/cratis-webpack": "8.10.0",
+        "@aksio/cratis-webpack": "8.11.1",
         "@types/chai": "4.3.3",
         "@types/chai-as-promised": "7.1.5",
         "@types/mocha": "10.0.0",

--- a/Versions.props
+++ b/Versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <AksioDefaults>1.5.15</AksioDefaults>
-        <AksioCratis>8.10.0</AksioCratis>
+        <AksioCratis>8.11.1</AksioCratis>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Added

- Made Cratis optional and is now a resource that can be added
- Made MongoDB optional and is now a resource that can be added
- Made Azure Container registry optional and is now a resource that can be added

### Changed

- Changed `ConfigPath` to be `MountPath`

### Fixed

- Azure Files mounted storage for container apps was read only, made them writable.
- Setting HTTP logging to default information
- Explicitly setting Pulumi Organization to use
- Removing unwanted `Console.WriteLine()` in service bus renderer
- Adding JSON access log output for Nginx Ingresses
- Removing the `WriteTo` section for Serilog in `AppSettings.json` so that we get to override it.
