### PR TITLE
Fixing FQN for RenderedCompactJsonFormatter

### DIFF
--- a/Source/Reactions/Applications/AppSettingsUtils.cs
+++ b/Source/Reactions/Applications/AppSettingsUtils.cs
@@ -43,7 +43,7 @@ public static class AppSettingsUtils
                     ["Name"] = "Console",
                     ["Args"] = new JsonObject()
                     {
-                        ["formatter"] = "Aksio.Cratis.Applications.Logging.RenderedCompactJsonFormatter, Aksio.Cratis.Applications"
+                        ["formatter"] = "Aksio.Applications.Serilog.RenderedCompactJsonFormatter, Aksio.Applications.Serilog@"
                     }
                 }
             }

--- a/Source/Reactions/Applications/Templates/appsettings.json.hbs
+++ b/Source/Reactions/Applications/Templates/appsettings.json.hbs
@@ -30,7 +30,7 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "formatter": "Aksio.Cratis.Applications.Logging.RenderedCompactJsonFormatter, Aksio.Cratis.Applications"
+                    "formatter": "Aksio.Applications.Serilog.RenderedCompactJsonFormatter, Aksio.Applications.Serilog"
                 }
             }
         ]


### PR DESCRIPTION
### Fixed

- Fixing the fully qualified name for the custom Serilog formatter we use. This has moved into a different repository.
