### PR TITLE
Adding tenant_id cookie using  the tenant_id from the auth / ingress middleware

### DIFF
--- a/Source/Reactions/Applications/Templates/nginx.conf.hbs
+++ b/Source/Reactions/Applications/Templates/nginx.conf.hbs
@@ -8,17 +8,17 @@ error_log /dev/stderr info;
 http {
     log_format logger-json escape=json '{"source": "nginx", "time": $msec, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status,  "user_agent": "$http_user_agent", "resp_time": $request_time, "upstream_addr": "$upstream_addr", "x_forwarded_for": "$http_x_forwarded_for"}';
     access_log /dev/stdout logger-json;
-    
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
     }
-    
+
     map $auth_resp_x_ms_client_principal $x_principal {
         default $auth_resp_x_ms_client_principal;
         "" $http_x_ms_client_principal;
     }
-    
+
     # We are limited by the Container App ingress, but keeping the limits here anyways
     # Read more here: https://learn.microsoft.com/en-us/azure/container-apps/ingress
     client_max_body_size        2048m;
@@ -26,7 +26,7 @@ http {
     proxy_send_timeout          7200;
     proxy_read_timeout          7200;
     send_timeout                7200;
-    
+
     client_header_timeout       7200;
     client_body_timeout         7200;
     fastcgi_read_timeout        7200;
@@ -34,26 +34,26 @@ http {
     fastcgi_buffer_size         128k;
     proxy_buffers               8 16k;
     proxy_buffer_size           32k;
-    
+
     add_header Cache-Control "no-cache";
-    
+
     server {
         listen 80;
         auth_request /auth;
-        
+
         gzip on;
         gzip_vary on;
         gzip_min_length 10240;
         gzip_proxied expired no-cache no-store private auth;
         gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
         gzip_disable "MSIE [1-6]\.";
-        
+
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header accept-encoding deflate;
-        
+
         # Main auth endpoint for regular requests
         location = /auth {
             internal;
@@ -61,28 +61,28 @@ http {
             proxy_pass http://localhost:81/;
             proxy_set_header Host $http_host;
             proxy_set_header X-Original-URI $request_uri;
-            
+
             proxy_pass_request_body off;
             proxy_set_header Content-Length "";
         }
-        
+
         location /.cratis {
             return 403;
         }
-        
+
         location /.well-known/acme-challenge {
             auth_request off;
             root /config;
         }
-        
+
         location @auth_redirect {
             if ($auth_x_aksio_impersonation_redirect) {
                 return 302 $scheme://$http_host$auth_x_aksio_impersonation_redirect;
             }
-            
+
             return 401;
         }
-        
+
         {{#with Impersonation}}
         # Auth endpoint for authorizing an impersonation
         location = /auth/impersonation {
@@ -91,60 +91,63 @@ http {
             proxy_pass http://localhost:81/.aksio/impersonate/auth;
             proxy_set_header Host $http_host;
             proxy_set_header X-Original-URI $request_uri;
-        
+
             proxy_pass_request_body off;
             proxy_set_header Content-Length "";
         }
-        
+
         location /.aksio/impersonate {
             auth_request /auth/impersonation;
-        
+
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-        
+
             proxy_pass {{TargetUrl}};
         }
-        
+
         location /.aksio/impersonate/perform {
             auth_request /auth/impersonation;
             proxy_pass http://localhost:81;
             proxy_set_header Host $http_host;
         }
-        
+
         {{/with}}
         location /.aksio {
             rewrite ^/.aksio(/.*)$ $1 break;
             proxy_pass http://localhost:81;
             proxy_set_header Host $http_host;
         }
-        
+
         {{#Routes}}
         location {{Path}} {
             error_page 401 = @auth_redirect;
-            
+
             {{#if Resolver}}
             # Specifies DNS server (this becomes necessary when doing regexp location to proxy_pass in nginx as the target-host lookup changes from startup to runtime)
             resolver {{Resolver}};
             {{/if}}
-            
+
             proxy_pass {{TargetUrl}};
-            
+
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            
+
             auth_request_set $auth_resp_x_ms_client_principal $upstream_http_x_ms_client_principal;
             proxy_set_header x-ms-client-principal $x_principal;
-            
+
             auth_request_set $auth_resp_tenant_id $upstream_http_tenant_id;
             proxy_set_header Tenant-ID $auth_resp_tenant_id;
             add_header Tenant-ID $auth_resp_tenant_id;
-            
+
+            # Adding the tenant id as a cookie for typically frontends to be able to know which tenant is being served
+            add_header Set-Cookie tenant_id=$auth_resp_tenant_id;
+
             auth_request_set $auth_resp_cookie $sent_http_set_cookie;
             add_header Set-Cookie $auth_resp_cookie;
-            
+
             auth_request_set $auth_x_aksio_impersonation_redirect $upstream_http_x_aksio_impersonation_redirect;
         }
-        
+
         {{/Routes}}
     }
 }


### PR DESCRIPTION
### Added

- Adding a cookie called `tenant_id` containing the tenant identifier resolved by the auth (IngressMiddleware). This will enable frontends to actually see the tenant identifier directly on all requests. And since we're doing it on an ingress level, no-one can fudge this.
